### PR TITLE
Clean directory before building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,4 +11,5 @@ xplatformBuildAndRunTests {
 	linuxTool = 'mono-msbuild15'
 	configuration = 'Release'
 	uploadNuGet = true
+	clean = true
 }


### PR DESCRIPTION
This causes the latest dogfood package to get used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/12)
<!-- Reviewable:end -->
