### PR TITLE
Implement workaround for msbuild bug #3468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Implement workaround for [msbuild bug #3468](https://github.com/Microsoft/msbuild/issues/3468):
+  use @ as escape character instead of \\ (backslash) for `VersionRegex` property
+
 ## [2.0.1] - 2018-06-29
 
 ### Changed

--- a/Documentation/SIL.ReleaseTasks.md
+++ b/Documentation/SIL.ReleaseTasks.md
@@ -144,3 +144,6 @@ versions should be put in the changelog. The default for the `SetReleaseNotesPro
 follows the example given on the [Keep a Changelog](https://keepachangelog.com) website, which
 puts the version number in square brackets, e.g. `## [1.0.0] - 2017-06-20`. However, it's
 possible to set the `VersionRegex` property to allow parsing different formats.
+
+__NOTE:__ Due to [msbuild bug #3468](https://github.com/Microsoft/msbuild/issues/3468) the escape
+character is @ instead of \\ (backslash)! To insert @ in the regular expression, double it: @@.

--- a/SIL.ReleaseTasks.Tests/SetReleaseNotesPropertyTests.cs
+++ b/SIL.ReleaseTasks.Tests/SetReleaseNotesPropertyTests.cs
@@ -366,5 +366,42 @@ Added:
 "));
 		}
 
+		[Test]
+		public void CustomVersionRegex()
+		{
+			// Setup
+			var sut = new SetReleaseNotesProperty();
+			sut.BuildEngine = new MockEngine();
+			sut.VersionRegex = @"#+ @d+-@d+-@d+ @@[a-z]+ @(([^)]+)@)|## Unreleased";
+			_tempFile = Path.GetTempFileName();
+
+			File.WriteAllText(_tempFile, @"
+# Change Log
+
+## Unreleased
+
+### Changed:
+
+- This is a unit test
+
+## 2018-07-02 @foo (5.0)
+
+### Added
+
+- added unit test");
+
+			sut.ChangelogFile = _tempFile;
+
+			// Exercise
+			var result = sut.Execute();
+
+			// Verify
+			Assert.That(result, Is.True);
+			Assert.That(sut.Value, Is.EqualTo(@"Changes since version 5.0
+
+Changed:
+- This is a unit test
+"));
+		}
 	}
 }

--- a/SIL.ReleaseTasks/SIL.ReleaseTasks.targets
+++ b/SIL.ReleaseTasks/SIL.ReleaseTasks.targets
@@ -3,7 +3,6 @@
 		Condition="'$(IgnoreSetReleaseNotesProp)' != 'true'">
 		<PropertyGroup>
 			<ChangelogFile Condition="'$(ChangelogFile)'==''">../CHANGELOG.md</ChangelogFile>
-			<VersionRegex Condition="'$(VersionRegex)'==''">#+ \[([^]]+)\]</VersionRegex>
 		</PropertyGroup>
 		<SetReleaseNotesProperty ChangelogFile="$(ChangelogFile)" VersionRegex="$(VersionRegex)">
 			<Output TaskParameter="Value" PropertyName="PackageReleaseNotes"/>


### PR DESCRIPTION
Use @ as escape character instead of \ (backslash) for
`VersionRegex` property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/14)
<!-- Reviewable:end -->
