### PR TITLE
Change output format for StampChangelogFileWithVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.3] - 2018-07-28
+
+### Changed
+
+- Change default date output format for `StampChangelogFileWithVersion` to
+  `yyyy-MM-dd` (instead of `dd/MMM/yyyy`).
+- Add new property `DateTimeFormat` to `StampChangelogFileWithVersion` task
+  to allow specification of output format.
+
+## [2.0.2] - 2018-07-02
+
 ### Fixed
 
 - Implement workaround for [msbuild bug #3468](https://github.com/Microsoft/msbuild/issues/3468):

--- a/Documentation/SIL.ReleaseTasks.md
+++ b/Documentation/SIL.ReleaseTasks.md
@@ -85,6 +85,8 @@ This assumes that a temporary line is currently at the top: e.g.
 
 - `VersionNumber`: The version number to put in the changelog file (required)
 
+- `DateTimeFormat`: The format string used to output the date. Default: `yyyy-MM-dd`
+
 ### Example
 
 ```xml
@@ -92,7 +94,7 @@ This assumes that a temporary line is currently at the top: e.g.
 
 <Target Name="Test">
   <StampChangelogFileWithVersion ChangelogFile="$(RootDir)/CHANGELOG.md"
-    VersionNumber="1.0.3" />
+    VersionNumber="1.0.3" DateTimeFormat="dd/MMM/yyyy" />
 </Target>
 ```
 

--- a/SIL.BuildTasks.Tests/UnitTestTasks/NUnitTests.cs
+++ b/SIL.BuildTasks.Tests/UnitTestTasks/NUnitTests.cs
@@ -124,6 +124,7 @@ namespace SIL.BuildTasks.Tests.UnitTestTasks
 		}
 
 		[Test]
+		[Ignore("No longer happens with Mono 5.12")]
 		[Platform(Exclude = "Win", Reason = "Doesn't crash on Windows. Instead we get an AccessViolationException that .NET handles")]
 		public void TestCrash_FailsBuild()
 		{

--- a/SIL.ReleaseTasks.Tests/StampChangelogFileWithVersionTests.cs
+++ b/SIL.ReleaseTasks.Tests/StampChangelogFileWithVersionTests.cs
@@ -11,7 +11,7 @@ namespace SIL.ReleaseTasks.Tests
 	public class StampChangelogFileWithVersionTests
 	{
 		[Test]
-		public void StampMarkdownWorks()
+		public void StampMarkdownWorksWithDefault()
 		{
 			var testMarkdown = new StampChangelogFileWithVersion();
 			using(var tempFiles = new TwoTempFilesForTest(Path.Combine(Path.GetTempPath(), "Test.md"), null))
@@ -20,11 +20,28 @@ namespace SIL.ReleaseTasks.Tests
 					new[] {"## DEV_VERSION_NUMBER: DEV_RELEASE_DATE", "*with some random content", "*does some things"});
 				testMarkdown.ChangelogFile = tempFiles.FirstFile;
 				testMarkdown.VersionNumber = "2.3.10";
-				var day = $"{DateTime.Now:dd/MMM/yyyy}";
 				Assert.That(testMarkdown.Execute(), Is.True);
 				var newContents = File.ReadAllLines(tempFiles.FirstFile);
 				Assert.That(newContents.Length == 3);
-				Assert.That(newContents[0], Is.EqualTo("## 2.3.10 " + day));
+				Assert.That(newContents[0], Is.EqualTo($"## 2.3.10 {DateTime.Now:yyyy-MM-dd}"));
+			}
+		}
+
+		[Test]
+		public void StampMarkdownCustomFormat()
+		{
+			var testMarkdown = new StampChangelogFileWithVersion();
+			using(var tempFiles = new TwoTempFilesForTest(Path.Combine(Path.GetTempPath(), "Test.md"), null))
+			{
+				File.WriteAllLines(tempFiles.FirstFile,
+					new[] {"## DEV_VERSION_NUMBER: DEV_RELEASE_DATE", "*with some random content", "*does some things"});
+				testMarkdown.ChangelogFile = tempFiles.FirstFile;
+				testMarkdown.VersionNumber = "2.3.10";
+				testMarkdown.DateTimeFormat = "dd/MMM/yyyy";
+				Assert.That(testMarkdown.Execute(), Is.True);
+				var newContents = File.ReadAllLines(tempFiles.FirstFile);
+				Assert.That(newContents.Length == 3);
+				Assert.That(newContents[0], Is.EqualTo($"## 2.3.10 {DateTime.Now:dd/MMM/yyyy}"));
 			}
 		}
 	}

--- a/SIL.ReleaseTasks/StampChangelogFileWithVersion.cs
+++ b/SIL.ReleaseTasks/StampChangelogFileWithVersion.cs
@@ -29,10 +29,14 @@ namespace SIL.ReleaseTasks
 		[Required]
 		public string VersionNumber { get; set; }
 
+		public string DateTimeFormat { get; set; }
+
 		public override bool Execute()
 		{
+			if (string.IsNullOrEmpty(DateTimeFormat))
+				DateTimeFormat = "yyyy-MM-dd";
 			var markdownLines = File.ReadAllLines(ChangelogFile);
-			markdownLines[0] = $"## {VersionNumber} {DateTime.Today:dd/MMM/yyyy}";
+			markdownLines[0] = $"## {VersionNumber} {DateTime.Today.ToString(DateTimeFormat)}";
 			File.WriteAllLines(ChangelogFile, markdownLines);
 			return true;
 		}


### PR DESCRIPTION
Default is now `yyyy-MM-dd` instead of `dd/MMM/yyyy`. Add new property
`DateTimeFormat` to allow different output.

+semver: minor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/15)
<!-- Reviewable:end -->
