### PR TITLE
Corrected logic in EnsureToolPath

### DIFF
--- a/SIL.BuildTasks/UnitTestTasks/NUnit.cs
+++ b/SIL.BuildTasks/UnitTestTasks/NUnit.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
-using LibGit2Sharp.Handlers;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Win32;
@@ -239,7 +238,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 				bldr.Append(" --nothread");
 			if (!string.IsNullOrEmpty(OutputXmlFile))
 				bldr.AppendFormat(" \"--xml={0}\"", OutputXmlFile);
-			bldr.Append(" --labels"); 
+			bldr.Append(" --labels");
 			return bldr.ToString();
 		}
 
@@ -248,31 +247,31 @@ namespace SIL.BuildTasks.UnitTestTasks
 			if (!string.IsNullOrEmpty(ToolPath) &&
 				File.Exists(Path.Combine(ToolPath, RealProgramName)))
 			{
-				Console.WriteLine($"{nameof(EnsureToolPath)}: existing {nameof(ToolPath)} valid: {ToolPath}");
+				Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)}: existing {nameof(ToolPath)} valid: {ToolPath}");
 				return;
 			}
 
 			var pathEnvVar = Environment.GetEnvironmentVariable("PATH");
 			if (pathEnvVar != null)
 			{
-				Console.WriteLine($"{nameof(EnsureToolPath)} looking for {RealProgramName} in path: {pathEnvVar}");
+				Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} looking for {RealProgramName} in path: {pathEnvVar}");
 				ToolPath = pathEnvVar.Split(Path.PathSeparator)
 					.FirstOrDefault(dir => !string.IsNullOrEmpty(dir) && File.Exists(Path.Combine(dir, RealProgramName)));
 				if (ToolPath != null)
 				{
-					Console.WriteLine($"{nameof(EnsureToolPath)} result: {ToolPath}");
+					Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} result: {ToolPath}");
 					return;
 				}
 			}
 
 			var programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-			Console.WriteLine($"{nameof(EnsureToolPath)} looking for {RealProgramName} in {programFilesPath}");
+			Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} looking for {RealProgramName} in {programFilesPath}");
 			if (!string.IsNullOrEmpty(programFilesPath))
 			{
 				foreach (var dir in Directory.EnumerateDirectories(programFilesPath)
 					.Where(d => d != null && Path.GetFileName(d).StartsWith("NUnit")))
 				{
-					Console.WriteLine($"3a) EnsureToolPath examining {dir}");
+					Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} examining {dir}");
 
 					ToolPath = new[] {"bin", "nunit-console"}
 						.Select(s => Path.Combine(dir, s))
@@ -281,7 +280,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 					// ReSharper disable once InvertIf
 					if (ToolPath != null)
 					{
-						Console.WriteLine($"{nameof(EnsureToolPath)} result: {ToolPath}");
+						Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} result: {ToolPath}");
 						return;
 					}
 				}
@@ -290,13 +289,13 @@ namespace SIL.BuildTasks.UnitTestTasks
 			var keySoftware = Registry.CurrentUser.OpenSubKey("Software");
 			if (keySoftware != null && Environment.OSVersion.Platform == PlatformID.Win32NT)
 			{
-				Console.WriteLine($"{nameof(EnsureToolPath)} looking for {RealProgramName} under registry subkey {keySoftware.Name}");
+				Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} looking for {RealProgramName} under registry subkey {keySoftware.Name}");
 
 				var keyNUnitOrg = keySoftware.OpenSubKey("nunit.org");
 				var keyNUnit = keyNUnitOrg?.OpenSubKey("Nunit");
 				if (keyNUnit != null)
 				{
-					Console.WriteLine($"{nameof(EnsureToolPath)} looking for {RealProgramName} under registry subkey {keyNUnit.Name}");
+					Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} looking for {RealProgramName} under registry subkey {keyNUnit.Name}");
 
 					foreach (var verName in keyNUnit.GetSubKeyNames())
 					{
@@ -304,20 +303,20 @@ namespace SIL.BuildTasks.UnitTestTasks
 						if (keyVer == null)
 							continue;
 
-						Console.WriteLine($"{nameof(EnsureToolPath)} looking for {RealProgramName} under registry subkey {keyVer.Name}");
+						Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} looking for {RealProgramName} under registry subkey {keyVer.Name}");
 
 						var path = keyVer.GetValue("InstallDir").ToString();
 						if (string.IsNullOrEmpty(path) || !File.Exists(Path.Combine(path, RealProgramName)))
 							continue;
 
 						ToolPath = path;
-						Console.WriteLine($"{nameof(EnsureToolPath)} result: {ToolPath}");
+						Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} result: {ToolPath}");
 						return;
 					}
 				}
 			}
 			ToolPath = ".";
-			Console.WriteLine($"{nameof(EnsureToolPath)} fallback result: {ToolPath}");
+			Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)} fallback result: {ToolPath}");
 		}
 
 		protected override string TestProgramName => $"{GetType().Name} ({FixturePath})";

--- a/SIL.BuildTasks/UnitTestTasks/TestTask.cs
+++ b/SIL.BuildTasks/UnitTestTasks/TestTask.cs
@@ -225,7 +225,6 @@ namespace SIL.BuildTasks.UnitTestTasks
 				var msg = $"Starting program: {process.StartInfo.FileName} " +
 					$"({process.StartInfo.Arguments}) in {process.StartInfo.WorkingDirectory}";
 
-				Console.WriteLine(msg);
 				Log.LogMessage(MessageImportance.Low, msg);
 
 				process.Start();

--- a/SIL.BuildTasks/UnitTestTasks/TestTask.cs
+++ b/SIL.BuildTasks/UnitTestTasks/TestTask.cs
@@ -225,6 +225,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 				var msg = $"Starting program: {process.StartInfo.FileName} " +
 					$"({process.StartInfo.Arguments}) in {process.StartInfo.WorkingDirectory}";
 
+				Console.WriteLine(msg);
 				Log.LogMessage(MessageImportance.Low, msg);
 
 				process.Start();


### PR DESCRIPTION
The fix was specifically to the part of the logic that looks for nunit-console in ProgramFiles.

Refactoring to simplify logic for other parts of that method
Added output (to console) to make it easier to see where it looked for and/or found the nunit-console program to run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/22)
<!-- Reviewable:end -->
