### PR TITLE
Upgraded to Nunit 3.12

### DIFF
--- a/SIL.BuildTasks.Tests/SIL.BuildTasks.Tests.csproj
+++ b/SIL.BuildTasks.Tests/SIL.BuildTasks.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.8.0" />
     <!-- Don't remove NUnit.Runners.Net4 - this is needed for the NUnitTests fixture! -->
     <PackageReference Include="NUnit.Runners.Net4" Version="2.6.4" />

--- a/SIL.ReleaseTasks.Tests/SIL.ReleaseTasks.Tests.csproj
+++ b/SIL.ReleaseTasks.Tests/SIL.ReleaseTasks.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This was not done for any particular known benefit. I was looking at ConstrainStringByLine and I noticed we were out of date. Updating seems to be harmless. If there's a good reason not to upgrade, no problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/23)
<!-- Reviewable:end -->
