### PR TITLE
NUnit3 fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ build/nuget.exe
 *.nupkg
 packages/
 .idea/
+Release/
+Debug/
 
 .vs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.3.1] - 2020-05-19
+
+### Changed
+
+- `NUnit3` task: Deal with differing options in `NUnit.ConsoleRunner` versions
+
+### Fixed
+
+- `NUnit3` task: Fix output format on Linux
+
 ## [2.3.0] - 2020-04-15
 
 ### Added
 
 - Add `NormalizeLocales` Task to help work with Crowdin Localized files
-
-### Added
-
 - Create symbol nuget package
 
 ## [2.2.0] - 2018-12-11

--- a/SIL.BuildTasks/FileUpdate.cs
+++ b/SIL.BuildTasks/FileUpdate.cs
@@ -34,8 +34,8 @@ namespace SIL.BuildTasks
 		/// </summary>
 		public string DateFormat
 		{
-			get { return _dateFormat ?? "dd/MMM/yyyy"; }
-			set { _dateFormat = value; }
+			get => _dateFormat ?? "dd/MMM/yyyy";
+			set => _dateFormat = value;
 		}
 
 		public override bool Execute()

--- a/SIL.BuildTasks/MakeWixForDirTree/IdToGuidDatabase.cs
+++ b/SIL.BuildTasks/MakeWixForDirTree/IdToGuidDatabase.cs
@@ -89,10 +89,7 @@ namespace SIL.BuildTasks.MakeWixForDirTree
 				string ret;
 				return _guids.TryGetValue(id, out ret) ? ret : null;
 			}
-			set
-			{
-				_guids[id] = value;
-			}
+			set => _guids[id] = value;
 		}
 
 

--- a/SIL.BuildTasks/MakeWixForDirTree/MakeWixForDirTree.cs
+++ b/SIL.BuildTasks/MakeWixForDirTree/MakeWixForDirTree.cs
@@ -70,8 +70,8 @@ namespace SIL.BuildTasks.MakeWixForDirTree
 		 */
 		public string MatchRegExPattern
 		{
-			get { return _fileMatchPattern.ToString(); }
-			set { _fileMatchPattern = new Regex(value, RegexOptions.IgnoreCase); }
+			get => _fileMatchPattern.ToString();
+			set => _fileMatchPattern = new Regex(value, RegexOptions.IgnoreCase);
 		}
 
 		/// <summary>
@@ -79,8 +79,8 @@ namespace SIL.BuildTasks.MakeWixForDirTree
 		/// </summary>
 		public string IgnoreRegExPattern
 		{
-			get { return _ignoreFilePattern.ToString(); }
-			set { _ignoreFilePattern = new Regex(value, RegexOptions.IgnoreCase); }
+			get => _ignoreFilePattern.ToString();
+			set => _ignoreFilePattern = new Regex(value, RegexOptions.IgnoreCase);
 		}
 
 		/// <summary>

--- a/SIL.BuildTasks/UnitTestTasks/NUnit.cs
+++ b/SIL.BuildTasks/UnitTestTasks/NUnit.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2012-2018 SIL International
+// Copyright (c) 2012-2020 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
 using System;
@@ -173,13 +173,15 @@ namespace SIL.BuildTasks.UnitTestTasks
 			get
 			{
 				EnsureToolPath();
-				var programNameAndPath = Path.Combine(Path.GetFullPath(ToolPath), RealProgramName);
+				var programNameAndPath = RealProgramNameAndPath;
 				if (!File.Exists(programNameAndPath))
 					return null;
 
 				return IsMono ? "mono" : programNameAndPath;
 			}
 		}
+
+		protected string RealProgramNameAndPath => Path.Combine(Path.GetFullPath(ToolPath), RealProgramName);
 
 		protected override string ProgramArguments
 		{
@@ -190,7 +192,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 				{
 					EnsureToolPath();
 					bldr.Append("--debug "); // cause Mono to show filenames in stack trace
-					bldr.Append(Path.Combine(Path.GetFullPath(ToolPath), RealProgramName));
+					bldr.Append(RealProgramNameAndPath);
 				}
 				foreach (var item in Assemblies)
 				{
@@ -244,8 +246,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 
 		private void EnsureToolPath()
 		{
-			if (!string.IsNullOrEmpty(ToolPath) &&
-				File.Exists(Path.Combine(ToolPath, RealProgramName)))
+			if (!string.IsNullOrEmpty(ToolPath) && File.Exists(RealProgramNameAndPath))
 			{
 				Log.LogMessage(MessageImportance.Low, $"{nameof(EnsureToolPath)}: existing {nameof(ToolPath)} valid: {ToolPath}");
 				return;
@@ -276,7 +277,7 @@ namespace SIL.BuildTasks.UnitTestTasks
 					ToolPath = new[] {"bin", "nunit-console"}
 						.Select(s => Path.Combine(dir, s))
 						.FirstOrDefault(p => File.Exists(Path.Combine(p, RealProgramName)));
-					
+
 					// ReSharper disable once InvertIf
 					if (ToolPath != null)
 					{

--- a/build/NuGet.targets
+++ b/build/NuGet.targets
@@ -1,0 +1,91 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)/../</SolutionDir>
+
+		<!-- Enable the restore command to run before builds -->
+		<RestorePackages Condition="  '$(RestorePackages)' == '' ">true</RestorePackages>
+
+		<!-- Determines if package restore consent is required to restore packages -->
+		<RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">false</RequireRestoreConsent>
+
+		<!-- Download NuGet.exe if it does not already exist -->
+		<DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">true</DownloadNuGetExe>
+		<NuGetExeUrl>https://dist.nuget.org/win-x86-commandline/latest/nuget.exe</NuGetExeUrl>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<NuGetToolsPath>$(MSBuildThisFileDirectory)</NuGetToolsPath>
+		<PackagesConfig>$(ProjectDir)packages.config</PackagesConfig>
+
+		<!-- NuGet command -->
+		<NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)/nuget.exe</NuGetExePath>
+
+		<NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
+		<NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono $(NuGetExePath)</NuGetCommand>
+	</PropertyGroup>
+
+	<Target Name="CheckPrerequisites">
+		<!-- Raise an error if we're unable to locate nuget.exe  -->
+		<Error Condition="'$(DownloadNuGetExe)' != 'true' AND !Exists('$(NuGetExePath)')"
+			Text="Unable to locate '$(NuGetExePath)'" />
+		<!--
+		Take advantage of MsBuild's build dependency tracking to make sure that we only ever download nuget.exe once.
+		This effectively acts as a lock that makes sure that the download operation will only happen once and all
+		parallel builds will have to wait for it to complete.
+		-->
+		<MsBuild Targets="_DownloadNuGet" Projects="$(MSBuildThisFileFullPath)"
+			Properties="Configuration=NOT_IMPORTANT;DownloadNuGetExe=$(DownloadNuGetExe)" />
+	</Target>
+
+	<Target Name="_DownloadNuGet" Condition=" '$(DownloadNuGetExe)' == 'true' AND !Exists('$(NuGetExePath)')">
+		<DownloadNuGet OutputFilename="$(NuGetExePath)"
+			Condition="'$(OS)' == 'Windows_NT'" />
+		<Exec Command="wget $(NuGetExeUrl) || curl -O -L $(NuGetExeUrl)"
+			WorkingDirectory="$(NuGetToolsPath)"
+			Condition="'$(OS)' != 'Windows_NT'" />
+	</Target>
+
+	<ItemGroup>
+		<PackageConfigs Include="$(SolutionDir)/**/packages.config"/>
+	</ItemGroup>
+
+	<Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
+		<Exec Command='$(NuGetCommand) restore -Force "$(SolutionPath)"'
+			Condition="Exists('$(SolutionPath)')"/>
+		<Exec Command='$(NuGetCommand) restore -Force -SolutionDirectory "$(SolutionDir)" "%(PackageConfigs.FullPath)"'
+			Condition="!Exists('$(SolutionPath)')"/>
+	</Target>
+
+	<UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory"
+		AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll"
+		Condition=" '$(OS)' == 'Windows_NT' ">
+		<ParameterGroup>
+			<OutputFilename ParameterType="System.String" Required="true" />
+		</ParameterGroup>
+		<Task>
+			<Reference Include="System.Core" />
+			<Using Namespace="System" />
+			<Using Namespace="System.IO" />
+			<Using Namespace="System.Net" />
+			<Using Namespace="Microsoft.Build.Framework" />
+			<Using Namespace="Microsoft.Build.Utilities" />
+			<Code Type="Fragment" Language="cs">
+				<![CDATA[
+				try {
+					OutputFilename = Path.GetFullPath(OutputFilename);
+
+					Log.LogMessage("Downloading latest version of NuGet.exe...");
+					WebClient webClient = new WebClient();
+					webClient.DownloadFile("$(NuGetExeUrl)", OutputFilename);
+
+					return true;
+				}
+				catch (Exception ex) {
+					Log.LogErrorFromException(ex);
+					return false;
+				}
+			]]>
+			</Code>
+		</Task>
+	</UsingTask>
+</Project>

--- a/build/SIL.BuildTasks.proj
+++ b/build/SIL.BuildTasks.proj
@@ -1,4 +1,4 @@
-<Project  ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTarget="Test">
+<Project  ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Test">
 	<PropertyGroup>
 		<RootDir Condition="'$(RootDir)'==''">$(MSBuildProjectDirectory)/..</RootDir>
 		<Configuration Condition="'$(Configuration)'==''">Release</Configuration>
@@ -8,8 +8,13 @@
 		<SolutionPath>$(RootDir)/$(Solution)</SolutionPath>
 		<BuildingWithXBuild>$(_.EndsWith('xbuild'))</BuildingWithXBuild>
 		<FailTaskIfAnyTestsFail Condition="'$(FailTaskIfAnyTestsFail)' == ''">true</FailTaskIfAnyTestsFail>
-		<NuGetPackageDir Condition="'$(OS)'=='Windows_NT'">$(UserProfile)/.nuget/packages</NuGetPackageDir>
-		<NuGetPackageDir Condition="'$(OS)'!='Windows_NT'">$(Home)/.nuget/packages</NuGetPackageDir>
+		<ExtraExcludeCategories Condition="'$(OS)'!='Windows_NT'">KnownMonoIssue,</ExtraExcludeCategories>
+		<ExtraExcludeCategories Condition="'$(teamcity_version)' != '' Or '$(JENKINS_URL)' != ''">SkipOnTeamCity,$(ExtraExcludeCategories)</ExtraExcludeCategories>
+		<RestartBuild Condition="!Exists('$(RootDir)/packages/NUnit.ConsoleRunner/tools/nunit3-console.exe')">true</RestartBuild>
+		<RestartBuild Condition="Exists('$(RootDir)/packages/NUnit.ConsoleRunner/tools/nunit3-console.exe')">false</RestartBuild>
+		<TeamCity Condition="'$(teamcity_version)' != ''">true</TeamCity>
+		<TeamCity Condition="'$(teamcity_version)' == ''">false</TeamCity>
+		<TestOutputXmlFile Condition="'$(teamcity_version)' == ''">$(RootDir)/output/$(Configuration)/TestResults.xml</TestOutputXmlFile>
 	</PropertyGroup>
 
 	<UsingTask TaskName="NUnit3" AssemblyFile="$(RootDir)/output/$(Configuration)/net461/SIL.BuildTasks.dll" />
@@ -20,7 +25,15 @@
 		AssemblyFile="$(agent_home_dir)/plugins/dotnetPlugin/bin/JetBrains.BuildServer.MSBuildLoggers.dll"
 		Condition=" '$(teamcity_version)' != '' And '$(OS)'!='Windows_NT'"/>
 
-	<Target Name="Build">
+	<Import Project="NuGet.targets"/>
+
+	<Target Name="RestoreBuildTasks" DependsOnTargets="CheckPrerequisites">
+		<Message Text="RestartBuild=$(RestartBuild)" />
+		<!-- Install NUnit.Console which has the required extensions (and NUnit.ConsoleRunner itself) as dependencies -->
+		<Exec Command='$(NuGetCommand) install NUnit.Console -excludeVersion -version 3.11.1 -solutionDirectory "$(RootDir)"' />
+	</Target>
+
+	<Target Name="Build" DependsOnTargets="RestoreBuildTasks">
 		<CallTarget Targets="Clean"/>
 		<CallTarget Targets="PackDogfood"/>
 		<CallTarget Targets="Compile"/>
@@ -55,34 +68,22 @@
 		<CallTarget Targets="TestOnly"/>
 	</Target>
 
-	<Target Name="TestOnly" DependsOnTargets="RunNUnitTC;RunNUnit"/>
-
-	<Target Name="RunNUnitTC" Condition="'$(teamcity_version)' != ''">
-		<ItemGroup>
-			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/net461/*.Tests.dll"/>
-		</ItemGroup>
-
-		<NUnitTeamCity
-			Assemblies="@(TestAssemblies)"
-			ExcludeCategory="SkipOnTeamCity;ByHand$(ExtraExcludeCategories)"
-			NUnitVersion="NUnit-3" />
-	</Target>
-
-	<Target Name="RunNUnit" Condition="'$(teamcity_version)' == ''">
+	<Target Name="TestOnly">
 		<ItemGroup>
 			<TestAssemblies Include="$(RootDir)/output/$(Configuration)/net461/*.Tests.dll"/>
 		</ItemGroup>
 
 		<NUnit3 Assemblies="@(TestAssemblies)"
-			ToolPath="$(NuGetPackageDir)/nunit.consolerunner/3.10.0/tools"
+			ToolPath="$(RootDir)/packages/NUnit.ConsoleRunner/tools"
 			TestInNewThread="false"
-			ExcludeCategory="$(excludedCategories)$(ExtraExcludeCategories)"
+			ExcludeCategory="ByHand;$(excludedCategories)$(ExtraExcludeCategories)"
 			WorkingDirectory="$(RootDir)/output/$(Configuration)/net461"
 			Force32Bit="$(useNUnit-x86)"
 			Verbose="true"
-			UseNUnit3Xml="true"
+			UseNUnit3Xml="false"
 			FailTaskIfAnyTestsFail="$(FailTaskIfAnyTestsFail)"
-			OutputXmlFile="$(RootDir)/output/$(Configuration)/TestResults.xml"/>
+			OutputXmlFile="$(TestOutputXmlFile)"
+			TeamCity="$(TeamCity)"/>
 	</Target>
 
 	<Target Name="Restore" DependsOnTargets="PackDogfood">


### PR DESCRIPTION
- fix output format on Linux. A semicolon separates commands on
  Linux which caused a warning when running the tests
- fix deprecation warning with NUnit.ConsoleRunner 3.11.
  `--labels=All` is deprecated in newer versions of ConsoleRunner.
  On the other hand `--labels=Before` wasn't available until 3.8.
  This change checks the version of ConsoleRunner and adds the
  correct option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/30)
<!-- Reviewable:end -->
