### PR TITLE
Support Keep a Changelog format input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for Keep a Changelog style CHANGELOG.md files in SIL.ReleaseTasks.
+
 ## [2.4.0] - 2021-01-22
 
 ### Added

--- a/SIL.ReleaseTasks.Tests/CreateChangelogEntryTests.cs
+++ b/SIL.ReleaseTasks.Tests/CreateChangelogEntryTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2018 SIL International
 // This software is licensed under the MIT License (http://opensource.org/licenses/MIT)
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 
@@ -31,17 +33,98 @@ namespace SIL.ReleaseTasks.Tests
 				sut.MaintainerInfo = "Steve McConnel <stephen_mcconnel@example.com>";
 				sut.DebianChangelog = changeLogFile;
 				sut.Distribution = "unstable";
+				string expectedDebianChangelog =
+@"myfavoriteapp (2.3.11) unstable; urgency=low
+
+  * with some random content
+  * does some things
+
+ -- Steve McConnel <stephen_mcconnel@example.com>  DATE_NOW
+
+myfavoriteapp (2.1.0~alpha1) unstable; urgency=low
+
+  * Initial Release for Linux.
+
+ -- Stephen McConnel <stephen_mcconnel@example.com>  Fri, 12 Jul 2013 14:57:59 -0500
+";
+				expectedDebianChangelog = expectedDebianChangelog.Replace("DATE_NOW", CreateChangelogEntry.DebianDate(sut.EntryDate));
 
 				// Execute
 				Assert.That(sut.Execute(), Is.True);
 
 				// Verify
 				var newContents = File.ReadAllLines(changeLogFile);
-				Assert.AreEqual(newContents.Length, 13, "New changelog entry was not the expected length");
-				Assert.That(newContents[0], Does.StartWith("myfavoriteapp (2.3.11) unstable; urgency=low"));
-				//Make sure that the author line matches debian standards for time offset and spacing around author name
+				string newContentsText = string.Join(Environment.NewLine, newContents);
+				Assert.That(newContentsText, Is.EqualTo(expectedDebianChangelog));
+				// Make sure that the author line matches debian standards for time offset and spacing around author name
 				Assert.That(newContents[5], Does.Match(" -- " + sut.MaintainerInfo + "  .*[+-]\\d\\d\\d\\d"));
 			}
+		}
+
+		[Test]
+		public void GenerateNewDebianChangelogEntry_InterpretsKAC()
+		{
+			// Setup
+			var sut = new CreateChangelogEntry();
+
+			string changelogContent =
+@"# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+<!-- Available types of changes:
+### Added
+### Changed
+### Fixed
+### Deprecated
+### Removed
+### Security
+-->
+
+## [Unreleased]
+
+## [2.3.11] - 2020-12-05
+
+### Changed
+- This to that.
+
+### Fixed
+- Unplanned bugs.
+
+## [1.2.3] - 2020-12-01
+
+### Added
+- New features.
+
+### Fixed
+- All bugs.";
+
+			string expectedNewChangelogEntry = @"myfavoriteapp (2.3.11) unstable; urgency=low
+
+  * Changed
+    * This to that.
+
+  * Fixed
+    * Unplanned bugs.
+
+ -- Steve McConnel <stephen_mcconnel@example.com>  DATE_NOW
+";
+			expectedNewChangelogEntry = expectedNewChangelogEntry.Replace("DATE_NOW", CreateChangelogEntry.DebianDate(sut.EntryDate));
+
+			sut.VersionNumber = "2.3.11";
+			sut.PackageName = "myfavoriteapp";
+			sut.MaintainerInfo = "Steve McConnel <stephen_mcconnel@example.com>";
+			sut.Distribution = "unstable";
+
+			// Execute
+			List<string> output = sut.GenerateNewDebianChangelogEntry(changelogContent.Split(new [] { Environment.NewLine }, StringSplitOptions.None));
+			string actualEntry = string.Join(Environment.NewLine, output);
+
+			// Verify
+			Assert.That(actualEntry, Is.EqualTo(expectedNewChangelogEntry));
 		}
 
 		[Test]

--- a/SIL.ReleaseTasks.Tests/CreateReleaseNotesHtmlTests.cs
+++ b/SIL.ReleaseTasks.Tests/CreateReleaseNotesHtmlTests.cs
@@ -38,6 +38,74 @@ namespace SIL.ReleaseTasks.Tests
 		}
 
 		[Test]
+		public void RemovesKACHead()
+		{
+			var testMarkdown = new CreateReleaseNotesHtml();
+			using(
+				var filesForTest = new TwoTempFilesForTest(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()+".Test.md"),
+					Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()+".Test.htm")))
+			{
+				string changelogContent =
+@"# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+<!-- Available types of changes:
+### Added
+### Changed
+### Fixed
+### Deprecated
+### Removed
+### Security
+-->
+
+## [Unreleased]
+
+## [2.3.4] - 2020-12-09
+
+### Changed
+- This to that.
+
+## [1.2.3] - 2020-12-08
+
+### Added
+- New features.
+
+### Fixed
+- All bugs.";
+
+				string expectedHtml =
+@"<html><head></head><body><div class='releasenotes'>
+<h2>[2.3.4] - 2020-12-09</h2>
+<h3>Changed</h3>
+<ul>
+<li>This to that.</li>
+</ul>
+<h2>[1.2.3] - 2020-12-08</h2>
+<h3>Added</h3>
+<ul>
+<li>New features.</li>
+</ul>
+<h3>Fixed</h3>
+<ul>
+<li>All bugs.</li>
+</ul>
+</div></body></html>";
+
+				File.WriteAllText(filesForTest.FirstFile, changelogContent);
+				testMarkdown.ChangelogFile = filesForTest.FirstFile;
+				testMarkdown.HtmlFile = filesForTest.SecondFile;
+				// SUT
+				Assert.That(testMarkdown.Execute(), Is.True);
+				string actualHtml = File.ReadAllText(filesForTest.SecondFile);
+				Assert.That(actualHtml, Is.EqualTo(expectedHtml));
+			}
+		}
+
+		[Test]
 		public void HtmlWithNoReleaseNotesElementIsCompletelyReplaced()
 		{
 			var testMarkdown = new CreateReleaseNotesHtml();

--- a/SIL.ReleaseTasks.Tests/StampChangelogFileWithVersionTests.cs
+++ b/SIL.ReleaseTasks.Tests/StampChangelogFileWithVersionTests.cs
@@ -44,5 +44,85 @@ namespace SIL.ReleaseTasks.Tests
 				Assert.That(newContents[0], Is.EqualTo($"## 2.3.10 {DateTime.Now:dd/MMM/yyyy}"));
 			}
 		}
+
+		[Test]
+		public void ProcessesKeepAChangelogFormat()
+		{
+			var testMarkdown = new StampChangelogFileWithVersion();
+			using(var tempFiles = new TwoTempFilesForTest(Path.Combine(Path.GetTempPath(), "CHANGELOG.md"), null))
+			{
+				string changelogContent =
+@"# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+<!-- Available types of changes:
+### Added
+### Changed
+### Fixed
+### Deprecated
+### Removed
+### Security
+-->
+
+## [Unreleased]
+
+### Changed
+- This to that.
+
+## [1.2.3] - 2020-12-08
+
+### Added
+- New features.
+
+### Fixed
+- All bugs.
+";
+
+				string expectedNewChangelogContent =
+@"# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+<!-- Available types of changes:
+### Added
+### Changed
+### Fixed
+### Deprecated
+### Removed
+### Security
+-->
+
+## [Unreleased]
+
+## [2.3.10] - DATE_HERE
+
+### Changed
+- This to that.
+
+## [1.2.3] - 2020-12-08
+
+### Added
+- New features.
+
+### Fixed
+- All bugs.
+";
+				expectedNewChangelogContent = expectedNewChangelogContent.Replace("DATE_HERE", DateTime.Today.ToString("yyyy-MM-dd"));
+				File.WriteAllText(tempFiles.FirstFile, changelogContent);
+				testMarkdown.ChangelogFile = tempFiles.FirstFile;
+				testMarkdown.VersionNumber = "2.3.10";
+				// SUT
+				Assert.That(testMarkdown.Execute(), Is.True);
+				var newContents = File.ReadAllText(tempFiles.FirstFile);
+				Assert.That(newContents, Is.EqualTo(expectedNewChangelogContent));
+			}
+		}
 	}
 }

--- a/SIL.ReleaseTasks/CreateChangelogEntry.cs
+++ b/SIL.ReleaseTasks/CreateChangelogEntry.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -29,9 +30,9 @@ namespace SIL.ReleaseTasks
 		[Required]
 		public string DebianChangelog { get; set; }
 
-		public string Distribution { get; set; }
-
-		public string Urgency { get; set; }
+		public string Distribution { get; set; } = "UNRELEASED";
+		public string Urgency { get; set; } = "low";
+		public DateTime EntryDate { get; set; } = DateTime.Now;
 
 		/// <summary>
 		/// Name and e-mail string
@@ -41,10 +42,6 @@ namespace SIL.ReleaseTasks
 		[SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
 		public override bool Execute()
 		{
-			if (string.IsNullOrEmpty(Distribution))
-				Distribution = "UNRELEASED";
-			if (string.IsNullOrEmpty(Urgency))
-				Urgency = "low";
 			var oldChangeLog = Path.ChangeExtension(DebianChangelog, ".old");
 			File.Delete(oldChangeLog);
 			File.Move(DebianChangelog, oldChangeLog);
@@ -59,31 +56,70 @@ namespace SIL.ReleaseTasks
 			{
 				MaintainerInfo = "Anonymous <anonymous@example.com>";
 			}
-			var markdownLines = File.ReadAllLines(ChangelogFile);
-			var newEntryLines = new List<string> {
-				// Write out the first markdown line as the changelog version line
+			string[] markdownLines = File.ReadAllLines(ChangelogFile);
+			List<string> newChangelogEntry = GenerateNewDebianChangelogEntry(markdownLines);
+			File.AppendAllLines(DebianChangelog, newChangelogEntry);
+		}
+
+		public List<string> GenerateNewDebianChangelogEntry(string[] markdownLines)
+		{
+			string mdText = string.Join(Environment.NewLine, markdownLines);
+			bool isKeepAChangelogFormat = CreateReleaseNotesHtml.RemoveKeepAChangelogHeadIfPresent(ref mdText);
+			markdownLines = mdText.Split(new [] { Environment.NewLine }, StringSplitOptions.None);
+
+			if (isKeepAChangelogFormat)
+			{
+				markdownLines = ConvertKACSectionsToBullets(markdownLines);
+			}
+
+			var newEntryLines = new List<string>
+			{
+				// Write out the first line as the changelog version line
 				$"{PackageName} ({VersionNumber}) {Distribution}; urgency={Urgency}",
 				string.Empty
 			};
-			for(var i = 1; i < markdownLines.Length; ++i)
+			// Skip a beginning blank line after the version header, if present.
+			// (Not to be confused with a Keep a Changelog heading, that would have been removed earlier.)
+			int contentStartingLineAfterVersionHeader = 1;
+			if (string.IsNullOrWhiteSpace(markdownLines[1]))
 			{
-				if(markdownLines[i].StartsWith("##"))
+				contentStartingLineAfterVersionHeader = 2;
+			}
+			for (var i = contentStartingLineAfterVersionHeader; i < markdownLines.Length; ++i)
+			{
+				if (markdownLines[i].StartsWith("##"))
+				{
 					break;
+				}
 				ConvertMarkdownLineToChangelogLine(markdownLines[i], newEntryLines);
 			}
-			newEntryLines.Add(string.Empty);
+			if (newEntryLines[newEntryLines.Count - 1] != string.Empty)
+			{
+				// End body with a blank line, if not already.
+				newEntryLines.Add(string.Empty);
+			}
 			// The debian changelog needs RFC 2822 format (Thu, 15 Oct 2015 08:25:16 -0500), which is not quite what .NET can provide
-			var debianDate = $"{DateTime.Now:ddd, dd MMM yyyy HH'|'mm'|'ss zzz}".Replace(":", "").Replace('|', ':');
+			var debianDate = CreateChangelogEntry.DebianDate(EntryDate);
 			newEntryLines.Add($" -- {MaintainerInfo}  {debianDate}");
 			newEntryLines.Add(string.Empty);
-			File.AppendAllLines(DebianChangelog, newEntryLines);
+			return newEntryLines;
+		}
+
+		/// <summary>
+		/// Format `when` suitable for debian/changelog files.
+		/// </summary>
+		public static string DebianDate(DateTime when)
+		{
+			return $"{when:ddd, dd MMM yyyy HH'|'mm'|'ss zzz}".Replace(":", "").Replace('|', ':');
 		}
 
 		private static void ConvertMarkdownLineToChangelogLine(string markdownLine, List<string> newEntryLines)
 		{
-			if (string.IsNullOrEmpty(markdownLine))
+			if (string.IsNullOrWhiteSpace(markdownLine))
+			{
+				newEntryLines.Add(string.Empty);
 				return;
-
+			}
 			// ReSharper disable once SwitchStatementMissingSomeCases
 			switch(markdownLine[0])
 			{
@@ -99,14 +135,36 @@ namespace SIL.ReleaseTasks
 				case '7':
 				case '8':
 				case '9':
-				case '0': // treat all unordered and ordered list items the same in the changelog
+				case '0':
+					// Treat all unordered and ordered list items the same in the changelog
 					newEntryLines.Add($"  *{markdownLine.Substring(1)}");
 					break;
-				case ' ': // Handle lists within lists, only second level items are handled, any further indentation is currently ignored
-					newEntryLines.Add($"    *{markdownLine.Trim().Substring(1).Trim('.')}");
+				case ' ':
+					// Handle lists within lists, only second level items are handled, any further indentation is
+					// currently ignored.
+					// TrimStart('.') is used to remove the period from "1.".
+					newEntryLines.Add($"    *{markdownLine.Trim().Substring(1).TrimStart('.')}");
 					break;
 			}
 		}
 
+		/// <summary>
+		/// Keep a Changelog style changelogs have sections like "Fixed" and "Added". Change these to bullets.
+		/// </summary>
+		private string[] ConvertKACSectionsToBullets(string[] mdLines)
+		{
+			return (new List<string>(mdLines))
+				// Indent everything, except headers and empty lines, so the section bullets are at the least level of indentation.
+				.Select((string line) => {
+					if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#"))
+					{
+						return line;
+					}
+					return line.Insert(0, "  ");
+				})
+				// Change ### section headers to first-level bullets.
+				.Select((string line) => line.Replace("### ", "- "))
+				.ToArray();
+		}
 	}
 }

--- a/SIL.ReleaseTasks/StampChangelogFileWithVersion.cs
+++ b/SIL.ReleaseTasks/StampChangelogFileWithVersion.cs
@@ -18,7 +18,8 @@ namespace SIL.ReleaseTasks
 	/// <inheritdoc />
 	/// <summary>
 	/// Replaces the first line in a markdown-style Changelog/Release file with the version and date
-	/// (Assumes that a temporary line is currently at the top: e.g. ## DEV_VERSION_NUMBER: DEV_RELEASE_DATE )
+	/// (Assumes that a temporary line is currently at the top: e.g. ## DEV_VERSION_NUMBER: DEV_RELEASE_DATE
+	/// or that the file contains a `## [Unreleased]` line.)
 	/// </summary>
 	[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
 	public class StampChangelogFileWithVersion : Task
@@ -29,16 +30,33 @@ namespace SIL.ReleaseTasks
 		[Required]
 		public string VersionNumber { get; set; }
 
-		public string DateTimeFormat { get; set; }
+		public string DateTimeFormat { get; set; } = "yyyy-MM-dd";
 
 		public override bool Execute()
 		{
-			if (string.IsNullOrEmpty(DateTimeFormat))
-				DateTimeFormat = "yyyy-MM-dd";
-			var markdownLines = File.ReadAllLines(ChangelogFile);
-			markdownLines[0] = $"## {VersionNumber} {DateTime.Today.ToString(DateTimeFormat)}";
+			List<string> markdownLines = new List<string>(File.ReadAllLines(ChangelogFile));
+			bool isKeepAChangelogFormat = markdownLines.Contains("## [Unreleased]");
+			if (isKeepAChangelogFormat)
+			{
+				AddNewVersionToKAC(markdownLines);
+			}
+			else
+			{
+				markdownLines[0] = $"## {VersionNumber} {DateTime.Today.ToString(DateTimeFormat)}";
+			}
 			File.WriteAllLines(ChangelogFile, markdownLines);
 			return true;
+		}
+
+		/// <summary>
+		/// For a Keep a Changelog file, with an `## [Unreleased]` line, insert a new version heading right
+		/// under the Unreleased heading, and leave the Unreleased heading.
+		/// </summary>
+		private void AddNewVersionToKAC(List<string> lines)
+		{
+			int unreleasedTagLocation = lines.FindIndex((string line) => line == "## [Unreleased]");
+			string newHeading = $"## [{VersionNumber}] - {DateTime.Today.ToString(DateTimeFormat)}";
+			lines.InsertRange(unreleasedTagLocation + 1, new string[] {"", newHeading});
 		}
 	}
 }


### PR DESCRIPTION
- SIL.ReleaseTasks expected a different format of changelog. Support
keepachangelog.com style changelogs as well, which have a preamble,
[Unreleased] version, and sub-headings for types of changes (eg
"Added", "Changed", ...).
- Remove the preamble and [Unreleased] heading, to not carry those
thru to the user.
- There is some unfortunate mixing of string, string[], and
List<string> that could use some smoothing out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/sil.buildtasks/40)
<!-- Reviewable:end -->
