### PR TITLE
Fix build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,12 @@
 #!groovy
-// Copyright (c) 2018-2020 SIL International
+// Copyright (c) 2018-2021 SIL International
 // This software is licensed under the MIT license (http://opensource.org/licenses/MIT)
 
 @Library('lsdev-pipeline-library') _
 
 xplatformBuildAndRunTests {
 	winNodeSpec = 'windows && vs2019 && netcore3.1'
-	linuxNodeSpec = 'linux64 && !packager && ubuntu && mono6'
+	linuxNodeSpec = 'linux64 && !packager && ubuntu && mono6 && !focal'
 	winTool = 'msbuild16'
 	linuxTool = 'mono-msbuild15'
 	configuration = 'Release'

--- a/SIL.BuildTasks.sln
+++ b/SIL.BuildTasks.sln
@@ -131,17 +131,11 @@ Global
 		{0DDD8153-5101-48BE-A080-9BAD036FE1F0}.Release|x64.ActiveCfg = Release|Any CPU
 		{0DDD8153-5101-48BE-A080-9BAD036FE1F0}.Release|x86.ActiveCfg = Release|Any CPU
 		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Debug|x64.Build.0 = Debug|Any CPU
 		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Debug|x86.Build.0 = Debug|Any CPU
 		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Release|Any CPU.Build.0 = Release|Any CPU
 		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Release|x64.ActiveCfg = Release|Any CPU
-		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Release|x64.Build.0 = Release|Any CPU
 		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Release|x86.ActiveCfg = Release|Any CPU
-		{75FC0B27-C903-46A1-BBA4-16D66B4F2A95}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Current mono version has problems building .NET Core 3.1 project.
This changes disables the automatic building of RecreateGuidDatabase.

It also prevents building on Ubuntu 20.04 (Focal) on CI because that
requires an updated GitVersion.