### PR TITLE
Use GitVersion.MsBuild instead of deprecated GitVersionTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.5.0] - 2021-02-24
+
 ### Added
-- Support for Keep a Changelog style CHANGELOG.md files in SIL.ReleaseTasks.
+
+- [SIL.ReleaseTasks] Support for Keep a Changelog style CHANGELOG.md files
 
 ## [2.4.0] - 2021-01-22
 
 ### Added
 
-- [SIL.BuildTasks] `Nunit3` task: Add `Process`, `Workers`, `Trace`, `Test`, `Agents`, and `Debug` properties for passing
-  on to the NUnit console runner for tuning and debugging
+- [SIL.BuildTasks] `Nunit3` task: Add `Process`, `Workers`, `Trace`, `Test`, `Agents`, and
+  `Debug` properties for passing on to the NUnit console runner for tuning and debugging
 
 - ReadMe.md Added windows instructions for building a package for local testing
 


### PR DESCRIPTION
This allows to build on Ubuntu 20.04 (Focal).

Also update copyright year for nuget packages.