### PR TITLE
Add package readme files

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -81,4 +81,4 @@ jobs:
         path: artifacts
 
     - name: Publish to Nuget
-      run: dotnet nuget push artifacts/*/Release/*.*nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.SILLSDEV_PUBLISH_NUGET_ORG}} --skip-duplicate
+      run: dotnet nuget push artifacts/*/Release/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.SILLSDEV_PUBLISH_NUGET_ORG}} --skip-duplicate

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 
 Several useful msbuild tasks.
 
+[![NuGet version (SIL.BuildTasks)](https://img.shields.io/nuget/v/SIL.BuildTasks.svg?style=flat-square)](https://www.nuget.org/packages/SIL.BuildTasks/)
 [![Build, Test and Pack](https://github.com/sillsdev/SIL.BuildTasks/actions/workflows/CI-CD.yml/badge.svg)](https://github.com/sillsdev/SIL.BuildTasks/actions/workflows/CI-CD.yml)
 
 ## Current Tasks

--- a/SIL.BuildTasks/SIL.BuildTasks.csproj
+++ b/SIL.BuildTasks/SIL.BuildTasks.csproj
@@ -3,6 +3,7 @@
     <RootNamespace>SIL.BuildTasks</RootNamespace>
     <Description>SIL.BuildTasks defines several msbuild tasks used in building our other projects.</Description>
     <AssemblyTitle>SIL.BuildTasks</AssemblyTitle>
+    <PackageReadmeFile>SIL.BuildTasks.md</PackageReadmeFile>
     <IsTool>true</IsTool>
   </PropertyGroup>
   <ItemGroup>
@@ -18,6 +19,13 @@
     <MakeDir Directories="$(PackageOutputPath)" />
     <WriteLinesToFile File="$(PackageOutputPath)/version.txt" Lines="$(GitVersion_NuGetVersion)" Overwrite="True" />
   </Target>
+
+  <ItemGroup>
+    <None Include="../Documentation/SIL.BuildTasks.md" Pack="true" PackagePath="/">
+      <Link>SIL.BuildTasks.md</Link>
+    </None>
+  </ItemGroup>
+
   <!-- Collect all dependencies and include them in the package itself, next to the Task assembly. -->
   <Target Name="CollectRuntimeOutputs" BeforeTargets="_GetPackageFiles">
     <MakeDir Directories="$(OutputPath)/lib/net472" />

--- a/SIL.ReleaseTasks/SIL.ReleaseTasks.csproj
+++ b/SIL.ReleaseTasks/SIL.ReleaseTasks.csproj
@@ -4,10 +4,17 @@
     <Description>Several release related tasks that can work with a CHANGELOG.md file.</Description>
     <AssemblyTitle>SIL.ReleaseTasks</AssemblyTitle>
     <BuildOutputTargetFolder>tools/$(TargetFramework)</BuildOutputTargetFolder>
+    <PackageReadmeFile>SIL.ReleaseTasks.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Markdig.Signed" Version="0.30.2" />
     <PackageReference Include="SIL.ReleaseTasks.Dogfood" Version="[2.3.3-*,)" PrivateAssets="All" />
   </ItemGroup>
   <Import Project="SIL.ReleaseTasks.Common.inc" />
+
+  <ItemGroup>
+    <None Include="../Documentation/SIL.ReleaseTasks.md" Pack="true" PackagePath="/">
+      <Link>SIL.ReleaseTasks.md</Link>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This change adds nuget package readme files. It also adds a badge
for the nuget package, and fixes improves the gha file to not try
to upload the .snupkg file because it already gets implicitly
uploaded by pushing the .nupkg file.