### PR TITLE
FileUpdate: do not fail if literal ReplacementText is found

### DIFF
--- a/SIL.BuildTasks.Tests/FileUpdateTests.cs
+++ b/SIL.BuildTasks.Tests/FileUpdateTests.cs
@@ -21,6 +21,8 @@ namespace SIL.BuildTasks.Tests
 			ExpectedResult = "There were approximately 35 frog princes.")]
 		[TestCase("There were 35 frog princes.", "(?<number>\\d+)", "approximately ${number}",
 			ExpectedResult = "There were approximately 35 frog princes.")]
+		[TestCase("</TargetFrameworkProfile>\r\n    <Version>0.0.0.0</Version> <!-- Replaced by FileUpdate in build/build.proj -->    <Authors>SIL</Authors>", "<Version>0\\.0\\.0\\.0</Version>", "<Version>3.3.0</Version>",
+			ExpectedResult = "</TargetFrameworkProfile>\r\n    <Version>3.3.0</Version> <!-- Replaced by FileUpdate in build/build.proj -->    <Authors>SIL</Authors>")]
 		public string GetModifiedContents_RegexTextMatched_Succeeds(string origContents, string regex, string replacement)
 		{
 			var updater = new FileUpdate
@@ -30,6 +32,18 @@ namespace SIL.BuildTasks.Tests
 			};
 
 			return updater.GetModifiedContents(origContents);
+		}
+
+		[TestCase("</TargetFrameworkProfile>\r\n    <Version>3.3.0</Version> <!-- Previously replaced by FileUpdate in build/build.proj -->    <Authors>SIL</Authors>", "<Version>0\\.0\\.0\\.0</Version>", "<Version>3.3.0</Version>")]
+		public void GetModifiedContents_RegexTextNotMatchedButReplacementTextFound_NoChangeOrError(string origContents, string regex, string replacement)
+		{
+			var updater = new FileUpdate
+			{
+				Regex = regex,
+				ReplacementText = replacement
+			};
+
+			Assert.That(updater.GetModifiedContents(origContents), NUnit.Framework.Is.EqualTo(origContents));
 		}
 
 		[TestCase("This is the story of the frog prince.", "princess", "soup")]

--- a/SIL.BuildTasks/FileUpdate.cs
+++ b/SIL.BuildTasks/FileUpdate.cs
@@ -60,7 +60,20 @@ namespace SIL.BuildTasks
 			{
 				var regex = new Regex(Regex);
 				if (!regex.IsMatch(content))
-					throw new Exception($"No replacements made. Regex: '{Regex}'; ReplacementText: '{ReplacementText}'");
+				{
+					// This check will generally only work if ReplacementText is just a literal string.
+					// If it contains references to regex match groups, and GetModifiedContents is run
+					// against a previously modified file with the same arguments, most likely no match
+					// will be found, and the "No replacements made" error will be displayed.
+					if (content.Contains(ReplacementText))
+					{
+						// Most likely, the replacement was already done an a previous build step.
+						return content;
+					}
+
+					throw new Exception($"No replacements made. Regex: '{Regex}'; " +
+						$"ReplacementText: '{ReplacementText}'");
+				}
 
 				var newContents = regex.Replace(content, ReplacementText);
 


### PR DESCRIPTION
Fixed regression caused by running FileUpdate on same file with same parameters (in multiple build steps). FileUpdate should not fail if literal ReplacementText is found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/SIL.BuildTasks/64)
<!-- Reviewable:end -->
