### PR TITLE
Consolidated SIL.BuildTasks to use same version of Markdig.Signed as SIL.ReleaseTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.1.1] - 2025-03-18
+### Changed
+
+- [SIL.BuildTasks] Upgraded dependency on Markdig.Signed to version 0.37.0 (to be consistent with SIL.ReleaseTasks)
+
 ## [3.1.0] - 2025-02-22
 
 ### Added
@@ -170,8 +175,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - First release as NuGet package
 
-[Unreleased]: https://github.com/sillsdev/SIL.BuildTasks/compare/v3.1.0...master
+[Unreleased]: https://github.com/sillsdev/SIL.BuildTasks/compare/v3.1.1...master
 
+[3.1.1]: https://github.com/sillsdev/SIL.BuildTasks/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/sillsdev/SIL.BuildTasks/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/sillsdev/SIL.BuildTasks/compare/v2.5.0...v3.0.0
 [2.5.0]: https://github.com/sillsdev/SIL.BuildTasks/compare/v2.4.0...v2.5.0

--- a/RecreateGuidDatabase/RecreateGuidDatabase.csproj
+++ b/RecreateGuidDatabase/RecreateGuidDatabase.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig.Signed" Version="0.37.0" />
     <PackageReference Include="SIL.ReleaseTasks.Dogfood" Version="[2.3.3-*,)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/SIL.BuildTasks.AWS/SIL.BuildTasks.AWS.csproj
+++ b/SIL.BuildTasks.AWS/SIL.BuildTasks.AWS.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.3.110.50" IncludeAssets="All" PrivateAssets="All" />
+    <PackageReference Include="Markdig.Signed" Version="0.37.0" />
     <PackageReference Include="SIL.ReleaseTasks.Dogfood" Version="[2.3.3-*,)" PrivateAssets="All" />
   </ItemGroup>
   <!-- Collect all dependencies and include them in the package itself, next to the Task assembly. -->

--- a/SIL.BuildTasks/SIL.BuildTasks.csproj
+++ b/SIL.BuildTasks/SIL.BuildTasks.csproj
@@ -7,6 +7,7 @@
     <IsTool>true</IsTool>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Markdig.Signed" Version="0.37.0" />
     <PackageReference Include="SIL.ReleaseTasks.Dogfood" Version="[2.3.3-*,)" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/SIL.ReleaseTasks.Tests/SIL.ReleaseTasks.Tests.csproj
+++ b/SIL.ReleaseTasks.Tests/SIL.ReleaseTasks.Tests.csproj
@@ -10,6 +10,7 @@
     <Reference Include="Microsoft.Build.Framework" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Markdig.Signed" Version="0.37.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />


### PR DESCRIPTION
Not sure if this needs to be noted in Changelog, and not sure whether it should be considered as a patch or a minor version update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/SIL.BuildTasks/74)
<!-- Reviewable:end -->
